### PR TITLE
クイズ回答後、正解不正解にかかわらず正解の選択肢を緑色で表示するように変更

### DIFF
--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -1,6 +1,6 @@
 import { Button, SimpleGrid, Text } from '@chakra-ui/react';
 import { BackToHomeButton } from './BackToHomeButton';
-import { CorrectOption, Question } from 'src/types/index';
+import { CorrectOption, Question, QuizStatus } from 'src/types/index';
 
 // 回答ボタンをレンダリングするためのコンポーネント
 type OptionButtonProps = {
@@ -26,26 +26,20 @@ const OptionButton = ({
 // 回答ボタンをレンダリングするためのコンポーネント
 type OptionButtonsProps = {
   question: Question;
-  selectedOption: CorrectOption | null;
-  isCorrect: boolean | null;
+  quizStatus: QuizStatus;
   checkAnswer: (option: CorrectOption) => void;
 };
 
-const OptionButtons = ({
-  question,
-  selectedOption,
-  isCorrect,
-  checkAnswer,
-}: OptionButtonsProps) => {
+const OptionButtons = ({ question, quizStatus, checkAnswer }: OptionButtonsProps) => {
   const optionLabels = ['A', 'B', 'C', 'D'];
+  const isDisabled = quizStatus !== 'ongoing';
 
   return (
     <SimpleGrid columns={2} spacing={4} w='100%'>
       {optionLabels.map((label) => {
         const option = label.toLowerCase() as CorrectOption;
-        const isSelected = selectedOption === option;
-        const isDisabled = selectedOption !== null;
-        const colorScheme = isSelected ? (isCorrect ? 'green' : 'red') : 'blue';
+        const isCorrectAnswer = question.correct_option === option;
+        const colorScheme = isCorrectAnswer && isDisabled ? 'green' : 'blue';
         const optionText = String(question[`option_${option}` as keyof Question]);
 
         return (
@@ -65,19 +59,14 @@ const OptionButtons = ({
 
 // 次の質問に進むボタンをレンダリングするためのコンポーネント
 type NextOrBackButtonProps = {
-  selectedOption: CorrectOption | null;
-  isCorrect: boolean | null;
+  quizStatus: QuizStatus;
   nextQuestionOrResult: () => void;
 };
 
-const NextOrBackButton = ({
-  selectedOption,
-  isCorrect,
-  nextQuestionOrResult,
-}: NextOrBackButtonProps) => {
-  if (selectedOption === null || isCorrect === null) return null;
+const NextOrBackButton = ({ quizStatus, nextQuestionOrResult }: NextOrBackButtonProps) => {
+  if (quizStatus === 'ongoing') return null;
 
-  return isCorrect ? (
+  return quizStatus === 'correct' ? (
     <Button colorScheme='blue' onClick={nextQuestionOrResult}>
       Next Question
     </Button>
@@ -89,33 +78,17 @@ const NextOrBackButton = ({
 // クイズの表示をレンダリングするためのコンポーネント
 type QuizProps = {
   question: Question;
-  selectedOption: CorrectOption | null;
-  isCorrect: boolean | null;
+  quizStatus: QuizStatus;
   checkAnswer: (option: CorrectOption) => void;
   nextQuestionOrResult: () => void;
 };
 
-export const Quiz = ({
-  question,
-  selectedOption,
-  isCorrect,
-  checkAnswer,
-  nextQuestionOrResult,
-}: QuizProps) => {
+export const Quiz = ({ question, quizStatus, checkAnswer, nextQuestionOrResult }: QuizProps) => {
   return (
     <>
       <Text fontSize='2xl'>{question.question}</Text>
-      <OptionButtons
-        question={question}
-        selectedOption={selectedOption}
-        isCorrect={isCorrect}
-        checkAnswer={checkAnswer}
-      />
-      <NextOrBackButton
-        selectedOption={selectedOption}
-        isCorrect={isCorrect}
-        nextQuestionOrResult={nextQuestionOrResult}
-      />
+      <OptionButtons question={question} quizStatus={quizStatus} checkAnswer={checkAnswer} />
+      <NextOrBackButton quizStatus={quizStatus} nextQuestionOrResult={nextQuestionOrResult} />
     </>
   );
 };

--- a/src/hooks/__test__/useQuiz.test.ts
+++ b/src/hooks/__test__/useQuiz.test.ts
@@ -52,46 +52,44 @@ describe('useQuiz', () => {
     const { result } = renderHook(() => useQuiz(mockQuestions));
 
     expect(result.current.currentQuestionIndex).toBe(0);
-    expect(result.current.selectedOption).toBe(null);
-    expect(result.current.isCorrect).toBe(null);
+    expect(result.current.quizStatus).toBe('ongoing');
   });
 
-  it('正しい答えを選択した場合、isCorrectがtrueになること', () => {
+  it('正しい答えを選択した場合、quizStatusがcorrectになること', () => {
     const { result } = renderHook(() => useQuiz(mockQuestions));
 
     act(() => {
       result.current.checkAnswer(mockQuestions[0].correct_option);
     });
 
-    expect(result.current.isCorrect).toBe(true);
+    expect(result.current.quizStatus).toBe('correct');
   });
 
-  it('不正解を選択した場合、isCorrectがfalseになること', () => {
+  it('不正解を選択した場合、quizStatusがincorrectになること', () => {
     const { result } = renderHook(() => useQuiz(mockQuestions));
 
     act(() => {
       result.current.checkAnswer('b' as CorrectOption);
     });
 
-    expect(result.current.isCorrect).toBe(false);
+    expect(result.current.quizStatus).toBe('incorrect');
   });
 
-  it('次の質問に進むと、選択肢と正誤がリセットされること', () => {
+  it('次の質問に進むと、選択肢と進行状況がリセットされること', () => {
     const { result } = renderHook(() => useQuiz(mockQuestions));
 
     act(() => {
       result.current.checkAnswer(mockQuestions[0].correct_option);
     });
 
-    expect(result.current.isCorrect).toBe(true);
+    expect(result.current.quizStatus).toBe('correct');
 
     act(() => {
       result.current.nextQuestionOrResult();
     });
 
     expect(result.current.currentQuestionIndex).toBe(1);
-    expect(result.current.selectedOption).toBe(null);
-    expect(result.current.isCorrect).toBe(null);
+    expect(result.current.quizStatus).toBe('ongoing');
   });
 
   it('最後の質問で正解した場合、/resultに遷移すること', () => {

--- a/src/hooks/useQuiz.ts
+++ b/src/hooks/useQuiz.ts
@@ -1,20 +1,19 @@
 import { useRouter } from 'next/router';
 import { useState } from 'react';
-import { Question, CorrectOption } from '../types';
+import { Question, CorrectOption, QuizStatus } from '../types';
 
 // クイズ状態を管理するためのカスタムフック
 export const useQuiz = (questions: Question[]) => {
-  // 現在の質問番号、選択した回答、回答の正否をuseStateで管理する
+  // 現在の質問番号、クイズの進行状況をuseStateで管理する
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
-  const [selectedOption, setSelectedOption] = useState<CorrectOption | null>(null);
-  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
+  const [quizStatus, setQuizStatus] = useState<QuizStatus>('ongoing');
+
   const currentQuestion = questions[currentQuestionIndex];
   const router = useRouter();
 
   // 回答をチェックするための関数
   const checkAnswer = (option: CorrectOption) => {
-    setSelectedOption(option);
-    setIsCorrect(option === currentQuestion.correct_option);
+    setQuizStatus(option === currentQuestion.correct_option ? 'correct' : 'incorrect');
   };
 
   // 次の質問に進むか、結果ページに遷移するかを決定する関数
@@ -29,16 +28,14 @@ export const useQuiz = (questions: Question[]) => {
   // 次の質問に進むための関数
   const goToNextQuestion = () => {
     setCurrentQuestionIndex(currentQuestionIndex + 1);
-    setSelectedOption(null);
-    setIsCorrect(null);
+    setQuizStatus('ongoing');
   };
 
   // クイズ状態を返す
   return {
     currentQuestion,
     currentQuestionIndex,
-    selectedOption,
-    isCorrect,
+    quizStatus,
     checkAnswer,
     nextQuestionOrResult,
   };

--- a/src/pages/quiz.tsx
+++ b/src/pages/quiz.tsx
@@ -10,14 +10,8 @@ import { useQuiz } from 'src/hooks/useQuiz';
 export default function QuizPage() {
   // データのフェッチとクイズ状態を取得する
   const { questions, isLoading, error } = useFetchQuestions();
-  const {
-    currentQuestion,
-    selectedOption,
-    isCorrect,
-    checkAnswer,
-    nextQuestionOrResult,
-    currentQuestionIndex,
-  } = useQuiz(questions);
+  const { currentQuestion, quizStatus, checkAnswer, nextQuestionOrResult, currentQuestionIndex } =
+    useQuiz(questions);
   const { usedPhone, fetchAnswerFromGPT } = useLifelines();
 
   // プログレスバーの値を計算する
@@ -59,8 +53,7 @@ export default function QuizPage() {
           {/* Quizコンポーネントに必要なプロップスを渡す */}
           <Quiz
             question={currentQuestion}
-            selectedOption={selectedOption}
-            isCorrect={isCorrect}
+            quizStatus={quizStatus}
             checkAnswer={checkAnswer}
             nextQuestionOrResult={nextQuestionOrResult}
           />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,3 +24,5 @@ export enum Difficulty {
   Hard = 'hard',
   Medium = 'medium',
 }
+
+export type QuizStatus = 'ongoing' | 'correct' | 'incorrect';


### PR DESCRIPTION
### やったこと
- クイズ回答後、正解不正解にかかわらず正解の選択肢を緑色で表示するように変更
不正解時に回答を赤色にしていましたが、青色のままにしました。
アプリの仕様を踏襲しました。

### 気になること
- 正解、不正解が区別しにくい。デザインの時に対応する。

### 次やること
- リファクタ：enumをunion型にする
わかりやすいのと、テストの型注釈が不要になり可読性が向上する
- #5