### PR TITLE
refactor: enumをunion型に

### DIFF
--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -1,6 +1,6 @@
 import { Button, SimpleGrid, Text } from '@chakra-ui/react';
 import { BackToHomeButton } from './BackToHomeButton';
-import { CorrectOption, Question } from 'src/types/index';
+import { CorrectOption, Question, QuizStatus } from 'src/types/index';
 
 // 回答ボタンをレンダリングするためのコンポーネント
 type OptionButtonProps = {
@@ -26,26 +26,20 @@ const OptionButton = ({
 // 回答ボタンをレンダリングするためのコンポーネント
 type OptionButtonsProps = {
   question: Question;
-  selectedOption: CorrectOption | null;
-  isCorrect: boolean | null;
+  quizStatus: QuizStatus;
   checkAnswer: (option: CorrectOption) => void;
 };
 
-const OptionButtons = ({
-  question,
-  selectedOption,
-  isCorrect,
-  checkAnswer,
-}: OptionButtonsProps) => {
+const OptionButtons = ({ question, quizStatus, checkAnswer }: OptionButtonsProps) => {
   const optionLabels = ['A', 'B', 'C', 'D'];
+  const isDisabled = quizStatus !== 'ongoing';
 
   return (
     <SimpleGrid columns={2} spacing={4} w='100%'>
       {optionLabels.map((label) => {
         const option = label.toLowerCase() as CorrectOption;
-        const isSelected = selectedOption === option;
-        const isDisabled = selectedOption !== null;
-        const colorScheme = isSelected ? (isCorrect ? 'green' : 'red') : 'blue';
+        const isCorrectAnswer = question.correct_option === option;
+        const colorScheme = isCorrectAnswer && isDisabled ? 'green' : 'blue';
         const optionText = String(question[`option_${option}` as keyof Question]);
 
         return (
@@ -65,19 +59,14 @@ const OptionButtons = ({
 
 // 次の質問に進むボタンをレンダリングするためのコンポーネント
 type NextOrBackButtonProps = {
-  selectedOption: CorrectOption | null;
-  isCorrect: boolean | null;
+  quizStatus: QuizStatus;
   nextQuestionOrResult: () => void;
 };
 
-const NextOrBackButton = ({
-  selectedOption,
-  isCorrect,
-  nextQuestionOrResult,
-}: NextOrBackButtonProps) => {
-  if (selectedOption === null || isCorrect === null) return null;
+const NextOrBackButton = ({ quizStatus, nextQuestionOrResult }: NextOrBackButtonProps) => {
+  if (quizStatus === 'ongoing') return null;
 
-  return isCorrect ? (
+  return quizStatus === 'correct' ? (
     <Button colorScheme='blue' onClick={nextQuestionOrResult}>
       Next Question
     </Button>
@@ -89,33 +78,17 @@ const NextOrBackButton = ({
 // クイズの表示をレンダリングするためのコンポーネント
 type QuizProps = {
   question: Question;
-  selectedOption: CorrectOption | null;
-  isCorrect: boolean | null;
+  quizStatus: QuizStatus;
   checkAnswer: (option: CorrectOption) => void;
   nextQuestionOrResult: () => void;
 };
 
-export const Quiz = ({
-  question,
-  selectedOption,
-  isCorrect,
-  checkAnswer,
-  nextQuestionOrResult,
-}: QuizProps) => {
+export const Quiz = ({ question, quizStatus, checkAnswer, nextQuestionOrResult }: QuizProps) => {
   return (
     <>
       <Text fontSize='2xl'>{question.question}</Text>
-      <OptionButtons
-        question={question}
-        selectedOption={selectedOption}
-        isCorrect={isCorrect}
-        checkAnswer={checkAnswer}
-      />
-      <NextOrBackButton
-        selectedOption={selectedOption}
-        isCorrect={isCorrect}
-        nextQuestionOrResult={nextQuestionOrResult}
-      />
+      <OptionButtons question={question} quizStatus={quizStatus} checkAnswer={checkAnswer} />
+      <NextOrBackButton quizStatus={quizStatus} nextQuestionOrResult={nextQuestionOrResult} />
     </>
   );
 };

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -1,6 +1,6 @@
 import { Button, SimpleGrid, Text } from '@chakra-ui/react';
 import { BackToHomeButton } from './BackToHomeButton';
-import { CorrectOption, Question, QuizStatus } from 'src/types/index';
+import { Option, Question, QuizStatus } from 'src/types/index';
 
 // 回答ボタンをレンダリングするためのコンポーネント
 type OptionButtonProps = {
@@ -27,7 +27,7 @@ const OptionButton = ({
 type OptionButtonsProps = {
   question: Question;
   quizStatus: QuizStatus;
-  checkAnswer: (option: CorrectOption) => void;
+  checkAnswer: (option: Option) => void;
 };
 
 const OptionButtons = ({ question, quizStatus, checkAnswer }: OptionButtonsProps) => {
@@ -37,7 +37,7 @@ const OptionButtons = ({ question, quizStatus, checkAnswer }: OptionButtonsProps
   return (
     <SimpleGrid columns={2} spacing={4} w='100%'>
       {optionLabels.map((label) => {
-        const option = label.toLowerCase() as CorrectOption;
+        const option = label.toLowerCase() as Option;
         const isCorrectAnswer = question.correct_option === option;
         const colorScheme = isCorrectAnswer && isDisabled ? 'green' : 'blue';
         const optionText = String(question[`option_${option}` as keyof Question]);
@@ -79,7 +79,7 @@ const NextOrBackButton = ({ quizStatus, nextQuestionOrResult }: NextOrBackButton
 type QuizProps = {
   question: Question;
   quizStatus: QuizStatus;
-  checkAnswer: (option: CorrectOption) => void;
+  checkAnswer: (option: Option) => void;
   nextQuestionOrResult: () => void;
 };
 

--- a/src/hooks/__test__/useFetchQuestions.test.ts
+++ b/src/hooks/__test__/useFetchQuestions.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import axios from 'axios';
 import { useFetchQuestions } from '../useFetchQuestions';
-import { CorrectOption, Difficulty, Question } from '@/types';
+import { Option, Difficulty, Question } from '@/types';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -12,12 +12,12 @@ const mockQuestions: Question[] = [
     id: 1,
     category_id: 1,
     question: 'テスト質問1',
-    correct_option: 'a' as CorrectOption,
+    correct_option: 'a',
     option_a: '選択肢1',
     option_b: '選択肢2',
     option_c: '選択肢3',
     option_d: '選択肢4',
-    difficulty: 'easy' as Difficulty,
+    difficulty: 'easy',
     created_at: new Date(),
     updated_at: new Date(),
   },
@@ -25,12 +25,12 @@ const mockQuestions: Question[] = [
     id: 2,
     category_id: 2,
     question: 'テスト質問2',
-    correct_option: 'b' as CorrectOption,
+    correct_option: 'b',
     option_a: '選択肢1',
     option_b: '選択肢2',
     option_c: '選択肢3',
     option_d: '選択肢4',
-    difficulty: 'easy' as Difficulty,
+    difficulty: 'easy',
     created_at: new Date(),
     updated_at: new Date(),
   },

--- a/src/hooks/__test__/useQuiz.test.ts
+++ b/src/hooks/__test__/useQuiz.test.ts
@@ -52,46 +52,44 @@ describe('useQuiz', () => {
     const { result } = renderHook(() => useQuiz(mockQuestions));
 
     expect(result.current.currentQuestionIndex).toBe(0);
-    expect(result.current.selectedOption).toBe(null);
-    expect(result.current.isCorrect).toBe(null);
+    expect(result.current.quizStatus).toBe('ongoing');
   });
 
-  it('正しい答えを選択した場合、isCorrectがtrueになること', () => {
+  it('正しい答えを選択した場合、quizStatusがcorrectになること', () => {
     const { result } = renderHook(() => useQuiz(mockQuestions));
 
     act(() => {
       result.current.checkAnswer(mockQuestions[0].correct_option);
     });
 
-    expect(result.current.isCorrect).toBe(true);
+    expect(result.current.quizStatus).toBe('correct');
   });
 
-  it('不正解を選択した場合、isCorrectがfalseになること', () => {
+  it('不正解を選択した場合、quizStatusがincorrectになること', () => {
     const { result } = renderHook(() => useQuiz(mockQuestions));
 
     act(() => {
       result.current.checkAnswer('b' as CorrectOption);
     });
 
-    expect(result.current.isCorrect).toBe(false);
+    expect(result.current.quizStatus).toBe('incorrect');
   });
 
-  it('次の質問に進むと、選択肢と正誤がリセットされること', () => {
+  it('次の質問に進むと、選択肢と進行状況がリセットされること', () => {
     const { result } = renderHook(() => useQuiz(mockQuestions));
 
     act(() => {
       result.current.checkAnswer(mockQuestions[0].correct_option);
     });
 
-    expect(result.current.isCorrect).toBe(true);
+    expect(result.current.quizStatus).toBe('correct');
 
     act(() => {
       result.current.nextQuestionOrResult();
     });
 
     expect(result.current.currentQuestionIndex).toBe(1);
-    expect(result.current.selectedOption).toBe(null);
-    expect(result.current.isCorrect).toBe(null);
+    expect(result.current.quizStatus).toBe('ongoing');
   });
 
   it('最後の質問で正解した場合、/resultに遷移すること', () => {

--- a/src/hooks/__test__/useQuiz.test.ts
+++ b/src/hooks/__test__/useQuiz.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import { Question, CorrectOption, Difficulty } from '../../types';
+import { Question, Option, Difficulty } from '../../types';
 import { useQuiz } from '../useQuiz';
 
 // next/routerのモック
@@ -23,12 +23,12 @@ const mockQuestions: Question[] = [
     id: 1,
     category_id: 1,
     question: 'テスト質問1',
-    correct_option: 'a' as CorrectOption,
+    correct_option: 'a',
     option_a: '選択肢1',
     option_b: '選択肢2',
     option_c: '選択肢3',
     option_d: '選択肢4',
-    difficulty: 'easy' as Difficulty,
+    difficulty: 'easy',
     created_at: new Date(),
     updated_at: new Date(),
   },
@@ -36,16 +36,23 @@ const mockQuestions: Question[] = [
     id: 2,
     category_id: 2,
     question: 'テスト質問2',
-    correct_option: 'b' as CorrectOption,
+    correct_option: 'b',
     option_a: '選択肢1',
     option_b: '選択肢2',
     option_c: '選択肢3',
     option_d: '選択肢4',
-    difficulty: 'easy' as Difficulty,
+    difficulty: 'easy',
     created_at: new Date(),
     updated_at: new Date(),
   },
 ];
+
+const getIncorrectOption = (correctOption: Option): Option => {
+  const options: Option[] = ['a', 'b', 'c', 'd'];
+  const incorrectOptions = options.filter((option) => option !== correctOption);
+  const randomIndex = Math.floor(Math.random() * incorrectOptions.length);
+  return incorrectOptions[randomIndex];
+};
 
 describe('useQuiz', () => {
   it('初期状態が正しいこと', () => {
@@ -67,9 +74,10 @@ describe('useQuiz', () => {
 
   it('不正解を選択した場合、quizStatusがincorrectになること', () => {
     const { result } = renderHook(() => useQuiz(mockQuestions));
+    const incorrectOption = getIncorrectOption(mockQuestions[0].correct_option);
 
     act(() => {
-      result.current.checkAnswer('b' as CorrectOption);
+      result.current.checkAnswer(incorrectOption);
     });
 
     expect(result.current.quizStatus).toBe('incorrect');

--- a/src/hooks/useQuiz.ts
+++ b/src/hooks/useQuiz.ts
@@ -1,20 +1,19 @@
 import { useRouter } from 'next/router';
 import { useState } from 'react';
-import { Question, CorrectOption } from '../types';
+import { Question, CorrectOption, QuizStatus } from '../types';
 
 // クイズ状態を管理するためのカスタムフック
 export const useQuiz = (questions: Question[]) => {
-  // 現在の質問番号、選択した回答、回答の正否をuseStateで管理する
+  // 現在の質問番号、クイズの進行状況をuseStateで管理する
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
-  const [selectedOption, setSelectedOption] = useState<CorrectOption | null>(null);
-  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
+  const [quizStatus, setQuizStatus] = useState<QuizStatus>('ongoing');
+
   const currentQuestion = questions[currentQuestionIndex];
   const router = useRouter();
 
   // 回答をチェックするための関数
   const checkAnswer = (option: CorrectOption) => {
-    setSelectedOption(option);
-    setIsCorrect(option === currentQuestion.correct_option);
+    setQuizStatus(option === currentQuestion.correct_option ? 'correct' : 'incorrect');
   };
 
   // 次の質問に進むか、結果ページに遷移するかを決定する関数
@@ -29,16 +28,14 @@ export const useQuiz = (questions: Question[]) => {
   // 次の質問に進むための関数
   const goToNextQuestion = () => {
     setCurrentQuestionIndex(currentQuestionIndex + 1);
-    setSelectedOption(null);
-    setIsCorrect(null);
+    setQuizStatus('ongoing');
   };
 
   // クイズ状態を返す
   return {
     currentQuestion,
     currentQuestionIndex,
-    selectedOption,
-    isCorrect,
+    quizStatus,
     checkAnswer,
     nextQuestionOrResult,
   };

--- a/src/hooks/useQuiz.ts
+++ b/src/hooks/useQuiz.ts
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import { useState } from 'react';
-import { Question, CorrectOption, QuizStatus } from '../types';
+import { Question, Option, QuizStatus } from '../types';
 
 // クイズ状態を管理するためのカスタムフック
 export const useQuiz = (questions: Question[]) => {
@@ -12,7 +12,7 @@ export const useQuiz = (questions: Question[]) => {
   const router = useRouter();
 
   // 回答をチェックするための関数
-  const checkAnswer = (option: CorrectOption) => {
+  const checkAnswer = (option: Option) => {
     setQuizStatus(option === currentQuestion.correct_option ? 'correct' : 'incorrect');
   };
 

--- a/src/pages/quiz.tsx
+++ b/src/pages/quiz.tsx
@@ -10,14 +10,8 @@ import { useQuiz } from 'src/hooks/useQuiz';
 export default function QuizPage() {
   // データのフェッチとクイズ状態を取得する
   const { questions, isLoading, error } = useFetchQuestions();
-  const {
-    currentQuestion,
-    selectedOption,
-    isCorrect,
-    checkAnswer,
-    nextQuestionOrResult,
-    currentQuestionIndex,
-  } = useQuiz(questions);
+  const { currentQuestion, quizStatus, checkAnswer, nextQuestionOrResult, currentQuestionIndex } =
+    useQuiz(questions);
   const { usedPhone, fetchAnswerFromGPT } = useLifelines();
 
   // プログレスバーの値を計算する
@@ -59,8 +53,7 @@ export default function QuizPage() {
           {/* Quizコンポーネントに必要なプロップスを渡す */}
           <Quiz
             question={currentQuestion}
-            selectedOption={selectedOption}
-            isCorrect={isCorrect}
+            quizStatus={quizStatus}
             checkAnswer={checkAnswer}
             nextQuestionOrResult={nextQuestionOrResult}
           />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,23 +6,14 @@ export type Question = {
   option_b: string;
   option_c: string;
   option_d: string;
-  correct_option: CorrectOption;
+  correct_option: Option;
   difficulty: Difficulty;
   created_at: Date;
   updated_at: Date;
 };
 
-export enum CorrectOption {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-  D = 'd',
-}
+export type Option = 'a' | 'b' | 'c' | 'd';
 
-export enum Difficulty {
-  Easy = 'easy',
-  Hard = 'hard',
-  Medium = 'medium',
-}
+export type Difficulty = 'easy' | 'medium' | 'hard';
 
 export type QuizStatus = 'ongoing' | 'correct' | 'incorrect';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,3 +24,5 @@ export enum Difficulty {
   Hard = 'hard',
   Medium = 'medium',
 }
+
+export type QuizStatus = 'ongoing' | 'correct' | 'incorrect';


### PR DESCRIPTION
### 変更理由
- テストの型注釈が不要になり可読性が向上する
- typescriptではenumよりunion型を使うべき
https://typescriptbook.jp/reference/values-types-variables/enum/enum-problems-and-alternatives-to-enums