### PR TITLE
refactor: useLifelinesをuseFetchAnswerFromGPTにして、全部PhoneAFriendのみから呼び出す

### DIFF
--- a/src/components/PhoneAFriend.tsx
+++ b/src/components/PhoneAFriend.tsx
@@ -10,37 +10,33 @@ import {
   Center,
 } from '@chakra-ui/react';
 import { useState } from 'react';
+import { useFetchAnswerFromGPT } from '@/hooks/useFetchAnswerFromGPT';
 import { Question } from '@/types';
 
 interface PhoneAFriendProps {
-  usedPhone: boolean;
-  fetchAnswerFromGPT: (query: string) => Promise<string>;
-  input: Question;
+  currentQuestion: Question;
 }
 
-export const PhoneAFriend = ({ usedPhone, fetchAnswerFromGPT, input }: PhoneAFriendProps) => {
+export const PhoneAFriend = ({ currentQuestion: input }: PhoneAFriendProps) => {
   const [gptAnswer, setGPTAnswer] = useState<string>('');
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [error, setError] = useState<any>(null);
+  const { fetchAnswerFromGPT, isLoading, error } = useFetchAnswerFromGPT();
+
+  // エラーがある場合はエラーメッセージを表示する
+  if (error) {
+    return <p>Error</p>;
+  }
 
   const handleOnClick = async () => {
-    try {
-      setIsLoading(true);
-      // 電話ボタンを押したら、GPT-3から回答を取得する
-      const answer = await fetchAnswerFromGPT(input.question);
-      setGPTAnswer(answer);
-    } catch (error) {
-      setError(error);
-    } finally {
-      setIsLoading(false);
-    }
+    // 電話ボタンを押したら、GPT-3から回答を取得する
+    const answer = await fetchAnswerFromGPT(input.question);
+    setGPTAnswer(answer);
   };
 
   return (
     <Popover placement='top'>
       <PopoverTrigger>
-        <Button colorScheme='teal' onClick={handleOnClick} isDisabled={usedPhone}>
-          {usedPhone ? 'Phone Used' : 'Phone a Friend'}
+        <Button colorScheme='teal' onClick={handleOnClick} isDisabled={gptAnswer !== ''}>
+          {gptAnswer !== '' ? 'Phone Used' : 'Phone a Friend'}
         </Button>
       </PopoverTrigger>
       <PopoverContent>

--- a/src/hooks/useFetchAnswerFromGPT.ts
+++ b/src/hooks/useFetchAnswerFromGPT.ts
@@ -1,12 +1,13 @@
 import axios from 'axios';
 import { useState } from 'react';
 
-export const useLifelines = () => {
-  const [usedPhone, setUsedPhone] = useState(false);
+export const useFetchAnswerFromGPT = () => {
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<any>(null);
 
   const fetchAnswerFromGPT = async (userInput: string) => {
     try {
-      setUsedPhone(true);
+      setIsLoading(true);
       const response = await axios.post('/api/lifelines/phoneAFriend', { userInput });
 
       if (response.status !== 200) {
@@ -14,12 +15,15 @@ export const useLifelines = () => {
       }
       return response.data.message;
     } catch (error) {
-      console.error(error);
+      setError;
+    } finally {
+      setIsLoading(false);
     }
   };
 
   return {
-    usedPhone,
     fetchAnswerFromGPT,
+    isLoading,
+    error,
   };
 };

--- a/src/pages/quiz.tsx
+++ b/src/pages/quiz.tsx
@@ -2,7 +2,6 @@ import { Center, Heading, Spinner, VStack } from '@chakra-ui/react';
 import Head from 'next/head';
 import { PhoneAFriend } from '@/components/PhoneAFriend';
 import { ProgressBar } from '@/components/ProgressBar';
-import { useLifelines } from '@/hooks/useLifelines';
 import { Quiz } from 'src/components/Quiz';
 import { useFetchQuestions } from 'src/hooks/useFetchQuestions';
 import { useQuiz } from 'src/hooks/useQuiz';
@@ -12,7 +11,6 @@ export default function QuizPage() {
   const { questions, isLoading, error } = useFetchQuestions();
   const { currentQuestion, quizStatus, checkAnswer, nextQuestionOrResult, currentQuestionIndex } =
     useQuiz(questions);
-  const { usedPhone, fetchAnswerFromGPT } = useLifelines();
 
   // プログレスバーの値を計算する
   const progressValue = (currentQuestionIndex / questions.length) * 100;
@@ -45,11 +43,7 @@ export default function QuizPage() {
           {/* プログレスバーを表示する */}
           <ProgressBar progressValue={progressValue} />
           {/* 電話ボタンを追加する */}
-          <PhoneAFriend
-            usedPhone={usedPhone}
-            fetchAnswerFromGPT={fetchAnswerFromGPT}
-            input={currentQuestion}
-          />
+          <PhoneAFriend currentQuestion={currentQuestion} />
           {/* Quizコンポーネントに必要なプロップスを渡す */}
           <Quiz
             question={currentQuestion}


### PR DESCRIPTION
### やったこと
- useFetchAnswerFromGPTとしてerror, isLoadingをまとめる（先程話したように）
- すべてPhoneAFriendから呼び出せるように

### 報告・相談
- これでかなりシンプルになったのでは？
- ヨシエさんの思い描いてる姿とマッチしてるか確認ください

### これからやること
- 同じようにaudienceを作成する