### PR TITLE
Refactor

### DIFF
--- a/src/components/FiftyFiftyButton.tsx
+++ b/src/components/FiftyFiftyButton.tsx
@@ -20,7 +20,7 @@ export const FiftyFiftyButton = ({ quizStatus, handleFiftyFifty }: FiftyFiftyBut
       onClick={handleOnClick}
       isDisabled={used || quizStatus !== 'ongoing'}
     >
-      {used ? 'Fifty-Fifty Used' : 'Fifty-Fifty'}
+      {used ? 'Used' : 'Fifty-Fifty'}
     </Button>
   );
 };

--- a/src/components/QuestionAndOptions.tsx
+++ b/src/components/QuestionAndOptions.tsx
@@ -83,7 +83,7 @@ const NextOrBackButton = ({ quizStatus, nextQuestionOrResult }: NextOrBackButton
 };
 
 // クイズの表示をレンダリングするためのコンポーネント
-type QuizProps = {
+type QuestionAndOptionsProps = {
   question: Question;
   quizStatus: QuizStatus;
   checkAnswer: (_option: Option) => void;
@@ -91,13 +91,13 @@ type QuizProps = {
   hiddenOptions: Option[];
 };
 
-export const Quiz = ({
+export const QuestionAndOptions = ({
   question,
   quizStatus,
   checkAnswer,
   nextQuestionOrResult,
   hiddenOptions,
-}: QuizProps) => {
+}: QuestionAndOptionsProps) => {
   return (
     <>
       <Text fontSize='2xl'>{question.question}</Text>

--- a/src/components/QuestionAndOptions.tsx
+++ b/src/components/QuestionAndOptions.tsx
@@ -1,5 +1,6 @@
 import { Button, SimpleGrid, Text } from '@chakra-ui/react';
 import { BackToHomeButton } from './BackToHomeButton';
+import { QUIZ_OPTIONS } from '@/constants';
 import { Option, Question, QuizStatus } from 'src/types/index';
 
 // 回答ボタンをレンダリングするためのコンポーネント
@@ -37,13 +38,12 @@ const OptionButtons = ({
   checkAnswer,
   hiddenOptions,
 }: OptionButtonsProps) => {
-  const optionLabels = ['A', 'B', 'C', 'D'];
   const isQuestionFinished = quizStatus !== 'ongoing';
 
   return (
     <SimpleGrid columns={2} spacing={4} w='100%'>
-      {optionLabels.map((label) => {
-        const option = label.toLowerCase() as Option;
+      {QUIZ_OPTIONS.map((option) => {
+        const label = option.toUpperCase();
         const isCorrectAnswer = question.correct_option === option;
         const isDisabled = isQuestionFinished || hiddenOptions.includes(option);
         const colorScheme = isCorrectAnswer && isQuestionFinished ? 'green' : 'blue';

--- a/src/components/QuizBox.tsx
+++ b/src/components/QuizBox.tsx
@@ -13,7 +13,6 @@ type QuizBoxProps = {
 };
 
 export const QuizBox = ({ questions }: QuizBoxProps) => {
-  console.log('hello');
   // クイズの状態を取得する
   const {
     currentQuestion,

--- a/src/components/QuizBox.tsx
+++ b/src/components/QuizBox.tsx
@@ -1,0 +1,55 @@
+import { Heading, HStack, Text, VStack } from '@chakra-ui/react';
+import { AskTheAudienceButton } from '@/components/AskTheAudienceButton';
+import { FiftyFiftyButton } from '@/components/FiftyFiftyButton';
+import { PhoneAFriendButton } from '@/components/PhoneAFriendButton';
+import { ProgressBar } from '@/components/ProgressBar';
+import { QuestionAndOptions } from '@/components/QuestionAndOptions';
+import { useFiftyFifty } from '@/hooks/useFiftyFifty';
+import { Question } from '@/types';
+import { useQuiz } from 'src/hooks/useQuiz';
+
+type QuizBoxProps = {
+  questions: Question[];
+};
+
+export const QuizBox = ({ questions }: QuizBoxProps) => {
+  console.log('hello');
+  // クイズの状態を取得する
+  const {
+    currentQuestion,
+    quizStatus,
+    checkAnswer,
+    nextQuestionOrResult,
+    currentQuestionIndex,
+    timeLeft,
+  } = useQuiz(questions);
+  // 50:50で隠す選択肢とコールバック関数を取得する
+  const { hiddenOptions, handleFiftyFifty } = useFiftyFifty(currentQuestion);
+
+  const progressValue = (currentQuestionIndex / questions.length) * 100;
+
+  return (
+    <>
+      <VStack spacing={8}>
+        <Heading as='h1' size='2xl'>
+          Quiz
+        </Heading>
+        <Text>Time left: {timeLeft}</Text>
+        <ProgressBar progressValue={progressValue} />
+        {/* Lifelinesを表示する */}
+        <HStack spacing={4}>
+          <PhoneAFriendButton currentQuestion={currentQuestion} quizStatus={quizStatus} />
+          <AskTheAudienceButton currentQuestion={currentQuestion} quizStatus={quizStatus} />
+          <FiftyFiftyButton quizStatus={quizStatus} handleFiftyFifty={handleFiftyFifty} />
+        </HStack>
+        <QuestionAndOptions
+          question={currentQuestion}
+          quizStatus={quizStatus}
+          checkAnswer={checkAnswer}
+          nextQuestionOrResult={nextQuestionOrResult}
+          hiddenOptions={hiddenOptions}
+        />
+      </VStack>
+    </>
+  );
+};

--- a/src/hooks/__test__/useFetchAnswerFromAudience.test.ts
+++ b/src/hooks/__test__/useFetchAnswerFromAudience.test.ts
@@ -33,7 +33,7 @@ describe('useFetchAnswerFromAudience', () => {
 
     const { result } = renderHook(() => useFetchAnswerFromAudience());
 
-    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isLoading).toBe(true);
 
     let answer;
     await act(async () => {
@@ -51,7 +51,7 @@ describe('useFetchAnswerFromAudience', () => {
 
     const { result } = renderHook(() => useFetchAnswerFromAudience());
 
-    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isLoading).toBe(true);
 
     await act(async () => {
       await result.current.fetchAnswerFromAudience(mockQuestion);

--- a/src/hooks/__test__/useFetchAnswerFromGPT.test.ts
+++ b/src/hooks/__test__/useFetchAnswerFromGPT.test.ts
@@ -15,7 +15,7 @@ describe('useFetchAnswerFromGPT', () => {
 
     const { result } = renderHook(() => useFetchAnswerFromGPT());
 
-    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isLoading).toBe(true);
 
     await act(async () => {
       const answer = await result.current.fetchAnswerFromGPT('テスト入力');
@@ -32,7 +32,7 @@ describe('useFetchAnswerFromGPT', () => {
 
     const { result } = renderHook(() => useFetchAnswerFromGPT());
 
-    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isLoading).toBe(true);
 
     await act(async () => {
       try {

--- a/src/hooks/useFetchAnswerFromAudience.ts
+++ b/src/hooks/useFetchAnswerFromAudience.ts
@@ -3,12 +3,11 @@ import { useState } from 'react';
 import { Question } from '@/types';
 
 export const useFetchAnswerFromAudience = () => {
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<any>(null);
 
   const fetchAnswerFromAudience = async (currentQuestion: Question) => {
     try {
-      setIsLoading(true);
       const response = await axios.post('/api/lifelines/askTheAudience', { currentQuestion });
       return response.data.message;
     } catch (error) {

--- a/src/hooks/useFetchAnswerFromGPT.ts
+++ b/src/hooks/useFetchAnswerFromGPT.ts
@@ -2,12 +2,11 @@ import axios from 'axios';
 import { useState } from 'react';
 
 export const useFetchAnswerFromGPT = () => {
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<any>(null);
 
   const fetchAnswerFromGPT = async (userInput: string) => {
     try {
-      setIsLoading(true);
       const response = await axios.post('/api/lifelines/phoneAFriend', { userInput });
       return response.data.message;
     } catch (error) {

--- a/src/hooks/useFetchQuestions.ts
+++ b/src/hooks/useFetchQuestions.ts
@@ -6,14 +6,13 @@ import { Question } from 'src/types/index';
 export const useFetchQuestions = () => {
   // 質問の配列、ローディング中かどうか、エラーが発生したかどうかをuseStateで管理する
   const [questions, setQuestions] = useState<Question[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<any>(null);
 
   // 質問を取得するためのAPIを呼び出すuseEffect
   useEffect(() => {
     const fetchQuestions = async () => {
       try {
-        setIsLoading(true);
         const response = await axios.get('/api/questions/random');
         setQuestions(response.data);
       } catch (error) {

--- a/src/pages/quiz.tsx
+++ b/src/pages/quiz.tsx
@@ -5,7 +5,6 @@ import { useFetchQuestions } from 'src/hooks/useFetchQuestions';
 
 export default function QuizPage() {
   const { questions, isLoading, error } = useFetchQuestions();
-  console.log('questions', questions);
 
   if (isLoading) {
     return (

--- a/src/pages/quiz.tsx
+++ b/src/pages/quiz.tsx
@@ -1,32 +1,13 @@
-import { Center, Heading, HStack, Spinner, Text, VStack } from '@chakra-ui/react';
+import { Center, Spinner } from '@chakra-ui/react';
 import Head from 'next/head';
-import { AskTheAudienceButton } from '@/components/AskTheAudienceButton';
-import { FiftyFiftyButton } from '@/components/FiftyFiftyButton';
-import { PhoneAFriendButton } from '@/components/PhoneAFriendButton';
-import { ProgressBar } from '@/components/ProgressBar';
-import { useFiftyFifty } from '@/hooks/useFiftyFifty';
-import { Quiz } from 'src/components/Quiz';
+import { QuizBox } from '@/components/QuizBox';
 import { useFetchQuestions } from 'src/hooks/useFetchQuestions';
-import { useQuiz } from 'src/hooks/useQuiz';
 
 export default function QuizPage() {
-  // データのフェッチとクイズ状態を取得する
   const { questions, isLoading, error } = useFetchQuestions();
-  const {
-    currentQuestion,
-    quizStatus,
-    checkAnswer,
-    nextQuestionOrResult,
-    currentQuestionIndex,
-    timeLeft,
-  } = useQuiz(questions);
-  const { hiddenOptions, handleFiftyFifty } = useFiftyFifty(currentQuestion);
+  console.log('questions', questions);
 
-  // プログレスバーの値を計算する
-  const progressValue = (currentQuestionIndex / questions.length) * 100;
-
-  // ロード中またはクイズがまだ読み込まれていない場合は、スピナーを表示する
-  if (isLoading || !currentQuestion) {
+  if (isLoading) {
     return (
       <Center h='100vh' bg='gray.100'>
         <Spinner size='xl' />;
@@ -34,9 +15,12 @@ export default function QuizPage() {
     );
   }
 
-  // エラーがある場合はエラーメッセージを表示する
   if (error) {
-    return <p>Error</p>;
+    return (
+      <Center h='100vh' bg='gray.100'>
+        <p>Error</p>;
+      </Center>
+    );
   }
 
   return (
@@ -45,29 +29,7 @@ export default function QuizPage() {
         <title>Quiz Page</title>
       </Head>
       <Center h='100vh' bg='gray.100'>
-        <VStack spacing={8}>
-          {/* クイズのタイトルを表示する */}
-          <Heading as='h1' size='2xl'>
-            Quiz
-          </Heading>
-          <Text>Time left: {timeLeft}</Text>
-          {/* プログレスバーを表示する */}
-          <ProgressBar progressValue={progressValue} />
-          {/* Lifelinesを表示する */}
-          <HStack spacing={4}>
-            <PhoneAFriendButton currentQuestion={currentQuestion} quizStatus={quizStatus} />
-            <AskTheAudienceButton currentQuestion={currentQuestion} quizStatus={quizStatus} />
-            <FiftyFiftyButton quizStatus={quizStatus} handleFiftyFifty={handleFiftyFifty} />
-          </HStack>
-          {/* Quizコンポーネントに必要なプロップスを渡す */}
-          <Quiz
-            question={currentQuestion}
-            quizStatus={quizStatus}
-            checkAnswer={checkAnswer}
-            nextQuestionOrResult={nextQuestionOrResult}
-            hiddenOptions={hiddenOptions}
-          />
-        </VStack>
+        <QuizBox questions={questions} />
       </Center>
     </>
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,6 @@ export type Difficulty = 'easy' | 'medium' | 'hard';
 export type QuizStatus = 'ongoing' | 'correct' | 'incorrect';
 
 export type OptionPercentage = {
-  option: string;
+  option: Option;
   percentage: number;
 };


### PR DESCRIPTION
### 主な変更点
- quizページのコンポーネントを切り出し
- データ取得関連のフックスのisLoadingの初期値をtrueに
変更理由：QuizBoxコンポーネントでのエラーハンドリングを減らすため。
chatGPTに聞いてみると、悪くはなさそうでした。
```
isLoadingの初期値をtrueにするのは、APIから質問を取得する前にローディング状態を示すために一般的に使用されるパターンです。そのため、問題ありません。

isLoadingがtrueの場合、ユーザーにはまだ読み込み中であることが伝わります。その後、APIからの応答が返され、isLoadingがfalseになると、ユーザーにはロードが完了したことが示されます。このため、isLoadingをtrueに設定することで、ユーザーに適切な情報を提供することができます。
```
ただ、この辺りはuseSWRなどのライブラリを使って、その仕様に合わせた方が良さそうです。
